### PR TITLE
Ability to message onself

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,22 @@ GPT:
 DALLE:
 - `!dalle A frog with a red hat is walking on a bridge.`
 
-The bot only responds to messages that are received by you, not sent by you.
+## Sending Messages to Yourself
+
+The WhatsApp ChatGPT bot now supports sending messages to yourself using the current authenticated account.
+This feature can be useful for various purposes, such as testing and research.
+
+To use this feature, simply send a message to your own phone number using the WhatsApp link `https://wa.me/phone`.
+This will take you to your own chat window.
+
+Once you have access to your own chat, you can use the `me<command>` syntax to issue commands to the bot.
+For example, to use the DALLE model, send a message with the command `medalle`. To use the GPT model, send a message with the command `megpt`.
+
+### Note
+
+- To use this feature, make sure that you have authenticated your WhatsApp account with the WhatsApp ChatGPT bot.
+- When sending messages to yourself, ensure that you are using the same account that is authenticated with the bot.
+  Otherwise, you will not receive any response.
 
 ## Disable prefix
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ require("dotenv").config()
 const prefixEnabled = process.env.PREFIX_ENABLED == "true"
 const gptPrefix = '!gpt'
 const dallePrefix = '!dalle'
+const selfGptPrefix = '!megpt'
+const selfDallePrefix = '!medalle'
 
 // Whatsapp Client
 const client = new Client()
@@ -55,6 +57,30 @@ const start = async () => {
             await handleMessageGPT(message, messageString)
         }
     })
+
+    // Whatsapp message to onself
+  client.on("message_create", async (message: any) => {
+    const messageString = message.body;
+    if (messageString.length == 0) return;
+    if (message.from == "status@broadcast") return;
+
+    if (message.fromMe === true && message.id.self === "out") {
+      // This can only work if prefix is used
+      // GPT (!gpt <prompt>)
+      if (messageString.startsWith(selfGptPrefix)) {
+        const prompt = messageString.substring(selfGptPrefix.length + 1);
+        await handleMessageGPT(message, prompt);
+        return;
+      }
+
+      // DALLE (!dalle <prompt>)
+      if (messageString.startsWith(selfDallePrefix)) {
+        const prompt = messageString.substring(selfDallePrefix.length + 1);
+        await handleMessageDALLE(message, prompt);
+        return;
+      }
+    }
+  });
 
     // Whatsapp initialization
     client.initialize()

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ dotenv.config();
 
 // Prefixes
 const prefixEnabled = process.env.PREFIX_ENABLED == "true"
-const shouldReplySelf = process.env.REPLY_SELF_ENABLED == "true"
+// const shouldReplySelf = process.env.REPLY_SELF_ENABLED == "true"
 const gptPrefix = '!gpt'
 const dallePrefix = '!dalle'
 const selfGptPrefix = '!megpt'
@@ -70,14 +70,14 @@ const start = async () => {
         await sendMessage(message);
     })
     
-    // reply to own message
+/*     // reply to own message
     client.on("message_create", async(message) => {
         if (message.fromMe && shouldReplySelf) {
             await sendMessage(message);
         }
-    });
+    }); */
 
-    // Whatsapp message to onself
+  // Whatsapp message to onself
   client.on("message_create", async (message: any) => {
     const messageString = message.body;
     if (messageString.length == 0) return;

--- a/src/openai.ts
+++ b/src/openai.ts
@@ -1,5 +1,9 @@
 import { ChatGPTAPI } from 'chatgpt'
 import { Configuration, OpenAIApi } from "openai";
+import dotenv from 'dotenv';
+
+// Load environment variables
+dotenv.config();
 
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 

--- a/src/openai.ts
+++ b/src/openai.ts
@@ -5,10 +5,6 @@ import dotenv from 'dotenv';
 // Load environment variables
 dotenv.config();
 
-// Environment variables
-import dotenv from 'dotenv';
-dotenv.config();
-
 // Open AI API Key
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY || "";
 


### PR DESCRIPTION
This pull request adds the ability to send messages to oneself on Whatsapp by creating a new prefix for the messages (e.g., `!megpt` for GPT prompts and `!medalle` for DALLE prompts). These messages will trigger the respective models and return responses to the sender.

To implement this feature, the code was modified to listen for a `message_create` event, which is triggered when a message is sent from the user's own phone number. The messages are then processed using the existing `handleMessageGPT` and `handleMessageDALLE` functions.

This PR includes the following changes:

Added ability to send messages to oneself using new prefixes
Modified code to listen for `message_create` event
Updated README.md to include instructions for self-messaging
Sync changes with currrent branch
Please review and merge this PR.