### PR TITLE
Features added: Storing sessions (Auto-Login without QRCode) + set own prefixes in .env

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -6,3 +6,7 @@ OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 # Whether or not to use prefixes !gpt and !dalle
 PREFIX_ENABLED=true
 
+# Set own prefixes for ChatGPT, DALL-E and configuration
+GPT_PREFIX=!gpt
+DALLE_PREFIX=!dalle
+AI_CONFIG_PREFIX=!config

--- a/.gitignore
+++ b/.gitignore
@@ -586,3 +586,4 @@ MigrationBackup/
 .ionide/
 
 # End of https://www.toptal.com/developers/gitignore/api/vs,intellij+all,node
+.DS_Store

--- a/src/cli/ui.ts
+++ b/src/cli/ui.ts
@@ -24,6 +24,11 @@ export const printLoading = () => {
 	s.start("Logging in");
 };
 
+export const printAuthenticated = () => {
+	s.stop("Session started!");
+	s.start("Opening session");
+};
+
 export const printOutro = () => {
 	s.stop("Loaded!");
 	outro("Whatsapp ChatGPT & DALLE is ready to use.");

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,9 +17,9 @@ interface IConfig {
 const config: IConfig = {
 	openAIAPIKey: process.env.OPENAI_API_KEY || "", // Default: ""
 	prefixEnabled: process.env.PREFIX_ENABLED == "true" || true, // Default: true
-	gptPrefix: "!gpt",
-	dallePrefix: "!dalle",
-	aiConfigPrefix: "!config"
+	gptPrefix: (process.env.GPT_PREFIX != "") ? process.env.GPT_PREFIX : "!gpt", // Default: !gpt
+	dallePrefix: (process.env.DALLE_PREFIX != "") ? process.env.DALLE_PREFIX : "!dalle", // Default: !dalle
+	aiConfigPrefix: (process.env.AI_CONFIG_PREFIX != "") ? process.env.AI_CONFIG_PREFIX : "!config", // Default: !config
 };
 
 export default config;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,10 +1,13 @@
 interface IConstants {
 	// WhatsApp status broadcast
 	statusBroadcast: string;
+	// WhatsApp session storage
+	sessionData: string;
 }
 
 const constants: IConstants = {
-	statusBroadcast: "status@broadcast"
+	statusBroadcast: "status@broadcast",
+	sessionData: "./session/session.json"
 };
 
 export default constants;


### PR DESCRIPTION
You only need to use the QR code to login the first time you start whatsapp-gpt. If you stop whatsapp-gpt and restart it, you will be automatically logged in (without scanning the QR code).
You can also set your own prefixes in .env.