### PR TITLE
Add AUTO_MODEL config

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -12,7 +12,10 @@ OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 MAX_MODEL_TOKENS=4096
 
 # Whether or not to use prefixes !gpt and !dalle
-PREFIX_ENABLED=true
+PREFIX_ENABLED=false
+
+# Automatically decide which model to use? (Don't use if prefix enabled)
+AUTO_MODEL=true
 
 # Set own prefixes for ChatGPT, DALL-E and configuration
 GPT_PREFIX=!gpt

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -7,6 +7,7 @@
 -   [Configuration](pages/gpt.md)
     -  [GPT configuration](pages/gpt.md)
     -  [Configure Prefix](pages/configure-prefix.md)
+    -  [Auto Decide Model](pages/auto_model.md)
 -   [Talk with the bot](pages/transcription.md)
     -   [Transcription with OpenAI Whisper](pages/transcription.md)
     -   [Text-To-Speech with Speech API](pages/tts.md)

--- a/docs/pages/auto_model.md
+++ b/docs/pages/auto_model.md
@@ -1,0 +1,11 @@
+# Auto Decide Model
+With this enabled, you can talk to the chatbot and it will automatically decide if it would be better for DALLE or GPT to respond to your input.
+
+## Disabling Auto Model Decision
+
+You can disable the auto model decision by setting the `AUTO_MODEL` environment variable in your `.env` file.
+
+## Notes
+**This will (currently) more than double the amount of tokens used per input!!!**
+
+With `AUTO_MODEL` enabled, you should keep prefixes OFF. If prefixes are on, then `AUTO_MODEL` does nothing.

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,9 @@ interface IConfig {
 	dallePrefix: string;
 	aiConfigPrefix: string;
 
+	// Auto select model
+	autoSelectModel: boolean;
+
 	// Voice transcription & Text-to-Speech
 	speechServerUrl: string;
 	ttsEnabled: boolean;
@@ -35,6 +38,9 @@ const config: IConfig = {
 	gptPrefix: process.env.GPT_PREFIX || "!gpt", // Default: !gpt
 	dallePrefix: process.env.DALLE_PREFIX || "!dalle", // Default: !dalle
 	aiConfigPrefix: process.env.AI_CONFIG_PREFIX || "!config", // Default: !config
+
+	// Auto select model
+	autoSelectModel: getEnvBooleanWithDefault("AUTO_MODEL", false),
 
 	// Speech API, Default: https://speech-service.verlekar.com
 	speechServerUrl: process.env.SPEECH_API_URL || "https://speech-service.verlekar.com",

--- a/src/handlers/gpt.ts
+++ b/src/handlers/gpt.ts
@@ -7,7 +7,7 @@ import { chatgpt } from "../providers/openai";
 import * as cli from "../cli/ui";
 import config from "../config";
 import { ttsRequest } from "../providers/speech";
-import { handleMessageDALLE } from "../handlers/dalle";
+import { AIType } from "../types/ai-decision";
 
 // Mapping from number to last conversation id
 const conversations = {};
@@ -81,10 +81,9 @@ const guessMessage = async (message: Message, prompt: string) => {
 
 		if (response.text.toLowerCase().includes("dalle")) {
 			// Assume that ChatGPT thinks it should handle the message
-			prompt = prompt.substring(config.dallePrefix.length + 1);
-			await handleMessageDALLE(message, prompt);
+			return AIType.dalle;
 		} else {
-			handleMessageGPT(message, prompt);
+			return AIType.gpt;
 		}
 
 	} catch (error: any) {

--- a/src/handlers/message.ts
+++ b/src/handlers/message.ts
@@ -8,7 +8,7 @@ import config from "../config";
 import * as cli from "../cli/ui";
 
 // ChatGPT & DALLE
-import { handleMessageGPT } from "../handlers/gpt";
+import { handleMessageGPT, guessMessage } from "../handlers/gpt";
 import { handleMessageDALLE } from "../handlers/dalle";
 import { handleMessageAIConfig } from "../handlers/ai-config";
 
@@ -75,10 +75,19 @@ async function handleIncomingMessage(message: Message) {
 		return;
 	}
 
-	if (!config.prefixEnabled) {
+	// if (!config.prefixEnabled) {
+	// 	// GPT (only <prompt>)
+	// 	await handleMessageGPT(message, messageString);
+	// 	return;
+	// }
+
+	if (!config.autoSelectModel && !config.prefixEnabled) {
 		// GPT (only <prompt>)
 		await handleMessageGPT(message, messageString);
 		return;
+	} else if (config.autoSelectModel && !config.prefixEnabled) {
+		// Automatically detect the model
+		await guessMessage(message, messageString);
 	}
 
 	// GPT (!gpt <prompt>)

--- a/src/handlers/message.ts
+++ b/src/handlers/message.ts
@@ -16,6 +16,7 @@ import { handleMessageAIConfig } from "../handlers/ai-config";
 import { TranscriptionMode } from "../types/transcription-mode";
 import { transcribeRequest } from "../providers/speech";
 import { transcribeAudioLocal } from "../providers/whisper-local";
+import { AIType } from "../types/ai-decision";
 
 // Handles message
 async function handleIncomingMessage(message: Message) {
@@ -75,19 +76,20 @@ async function handleIncomingMessage(message: Message) {
 		return;
 	}
 
-	// if (!config.prefixEnabled) {
-	// 	// GPT (only <prompt>)
-	// 	await handleMessageGPT(message, messageString);
-	// 	return;
-	// }
-
 	if (!config.autoSelectModel && !config.prefixEnabled) {
 		// GPT (only <prompt>)
 		await handleMessageGPT(message, messageString);
 		return;
 	} else if (config.autoSelectModel && !config.prefixEnabled) {
 		// Automatically detect the model
-		await guessMessage(message, messageString);
+		const model = await guessMessage(message, messageString);
+
+		if (model == AIType.dalle) {
+			await handleMessageDALLE(message, messageString);
+		} else if (model == AIType.gpt) {
+			await handleMessageGPT(message, messageString);
+		}
+		return;
 	}
 
 	// GPT (!gpt <prompt>)

--- a/src/types/ai-decision.ts
+++ b/src/types/ai-decision.ts
@@ -1,0 +1,4 @@
+export enum AIType {
+	dalle,
+	gpt
+}


### PR DESCRIPTION
When enabled, GPT will decide if it or DALLE should respond to the request. #67 

Manually tested, works relatively well in practice. This does use two requests per input. Future iteration(s) could get around this by requesting GPT to answer inline if it finds that it is the best option to respond rather than DALLE.

For example, the prompt could be modified to be
 `Given the following prompt, should ChatGPT handle this request, or should DALLE, an AI model that generates image? Respond with one word, either ChatGPT or DALLE. If ChatGPT is the best, then write "ChatGPT: " and then the response: ${prompt}`

or similar.