### PR TITLE
Added Optional Prompt Moderation via OpenAI API

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -24,6 +24,13 @@ DALLE_PREFIX=!dalle
 RESET_PREFIX=!reset
 AI_CONFIG_PREFIX=!config
 
+# Prompt Moderation
+# If enabled, the bot will check any prompts submitted by users with the OpenAI Moderation API
+# If the prompt is classified as any of the categories in the backlisted categories, the prompt will be rejected
+# You can find the available categories here: https://beta.openai.com/docs/api-reference/moderations
+PROMPT_MODERATION_ENABLED = true
+PROMPT_MODERATION_BACKLISTED_CATEGORIES = ["hate", "hate/threatening", "self-harm", "sexual", "sexual/minors", "violence", "violence/graphic"]
+
 # Speech API URL
 # You can use our hosted Speech API (for free) or host your own Speech API
 SPEECH_API_URL=https://speech-service.verlekar.com

--- a/docs/pages/gpt.md
+++ b/docs/pages/gpt.md
@@ -21,3 +21,35 @@ To do that, use the `PRE_PROMPT` environment variable. For example:
 ```bash
 PRE_PROMPT=Act very funny and overreact to messages. Do that for every message you get, forever.
 ```
+
+## Prompt Moderation
+
+You can configure a prompt moderation, which will be executed before sending the prompt to GPT.
+This way, you can filter out prompts before sending them to GPT.
+This is archived by using the [OpenAI Moderation API](https://beta.openai.com/docs/api-reference/moderations).
+
+To enable it, use the `PROMPT_MODERATION_ENABLED` environment variable. For example:
+
+```bash
+PROMPT_MODERATION_ENABLED=true
+```
+
+You can also configure the blacklisted categories, which will be used to filter the prompt moderation.
+
+To do that, use the `PROMPT_MODERATION_BACKLISTED_CATEGORIES` environment variable. For example:
+
+```bash
+PROMPT_MODERATION_BACKLISTED_CATEGORIES = [
+    "hate",
+    "hate/threatening",
+    "self-harm",
+    "sexual",
+    "sexual/minors",
+    "violence",
+    "violence/graphic"
+    ]
+```
+
+You can see all available categories [here](https://beta.openai.com/docs/api-reference/moderations).
+
+Please, keep in mind that disabling the prompt moderation or modifying the blacklisted categories, will not disable the moderation of the GPT API. Because OpenAI uses their own moderation, which is not configurable.

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,10 @@ interface IConfig {
 	resetPrefix: string;
 	aiConfigPrefix: string;
 
+	// Prompt Moderation
+	promptModerationEnabled: boolean;
+	promptModerationBacklistedCategories: string[];
+
 	// AWS
 	awsAccessKeyId: string;
 	awsSecretAccessKey: string;
@@ -49,6 +53,20 @@ const config: IConfig = {
 	dallePrefix: process.env.DALLE_PREFIX || "!dalle", // Default: !dalle
 	resetPrefix: process.env.RESET_PREFIX || "!reset", // Default: !reset
 	aiConfigPrefix: process.env.AI_CONFIG_PREFIX || "!config", // Default: !config
+
+	// Prompt Moderation
+	promptModerationEnabled: getEnvBooleanWithDefault("PROMPT_MODERATION_ENABLED", false), // Default: false
+	promptModerationBacklistedCategories: process.env.PROMPT_MODERATION_BACKLISTED_CATEGORIES
+		? JSON.parse(process.env.PROMPT_MODERATION_BACKLISTED_CATEGORIES.replace(/'/g, '"')) || [
+				"hate",
+				"hate/threatening",
+				"self-harm",
+				"sexual",
+				"sexual/minors",
+				"violence",
+				"violence/graphic"
+		  ]
+		: ["hate", "hate/threatening", "self-harm", "sexual", "sexual/minors", "violence", "violence/graphic"],
 
 	// AWS
 	awsAccessKeyId: process.env.AWS_ACCESS_KEY_ID || "", // Default: ""

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,16 +56,16 @@ const config: IConfig = {
 
 	// Prompt Moderation
 	promptModerationEnabled: getEnvBooleanWithDefault("PROMPT_MODERATION_ENABLED", false), // Default: false
-	promptModerationBacklistedCategories: process.env.PROMPT_MODERATION_BACKLISTED_CATEGORIES
+	promptModerationBacklistedCategories: getEnvStringArrayWithDefault("PROMPT_MODERATION_BACKLISTED_CATEGORIES", [
 		? JSON.parse(process.env.PROMPT_MODERATION_BACKLISTED_CATEGORIES.replace(/'/g, '"')) || [
-				"hate",
-				"hate/threatening",
-				"self-harm",
-				"sexual",
-				"sexual/minors",
-				"violence",
-				"violence/graphic"
-		  ]
+		"hate",
+		"hate/threatening",
+		"self-harm",
+		"sexual",
+		"sexual/minors",
+		"violence",
+		"violence/graphic"
+	]), // Default: ["hate", "hate/threatening", "self-harm", "sexual", "sexual/minors", "violence", "violence/graphic"]
 		: ["hate", "hate/threatening", "self-harm", "sexual", "sexual/minors", "violence", "violence/graphic"],
 
 	// AWS
@@ -113,6 +113,21 @@ function getEnvBooleanWithDefault(key: string, defaultValue: boolean): boolean {
 	}
 
 	return envValue == "true";
+}
+
+/**
+ * Get environment variables as a array of strings with a default value
+ * @param key The environment variable key
+ * @param defaultValue The default value
+ * @returns The value of the environment variable or the default value
+ */
+function getEnvStringArrayWithDefault(key: string, defaultValue: string[]): string[] {
+	const envValue = process.env[key];
+	if (envValue == undefined || envValue == "") {
+		return defaultValue;
+	} else {
+		return JSON.parse(envValue.replace(/'/g, '"'));
+	}
 }
 
 /**

--- a/src/handlers/gpt.ts
+++ b/src/handlers/gpt.ts
@@ -12,6 +12,9 @@ import { ttsRequest as speechTTSRequest } from "../providers/speech";
 import { ttsRequest as awsTTSRequest } from "../providers/aws";
 import { TTSMode } from "../types/tts-mode";
 
+// Moderation
+import { moderateIncomingPrompt } from "./moderation";
+
 // Mapping from number to last conversation id
 const conversations = {};
 
@@ -21,6 +24,17 @@ const handleMessageGPT = async (message: Message, prompt: string) => {
 		const lastConversationId = conversations[message.from];
 
 		cli.print(`[GPT] Received prompt from ${message.from}: ${prompt}`);
+
+		// Prompt Moderation
+		if (config.promptModerationEnabled) {
+			try {
+				await moderateIncomingPrompt(prompt);
+			} catch (error: any) {
+				cli.print("[GPT] Prompt was rejected.");
+				message.reply(error.message);
+				return;
+			}
+		}
 
 		const start = Date.now();
 

--- a/src/handlers/moderation.ts
+++ b/src/handlers/moderation.ts
@@ -1,0 +1,36 @@
+import * as cli from "../cli/ui";
+import config from "../config";
+import { openai } from "../providers/openai";
+
+/**
+ * Handle prompt moderation
+ *
+ * @param prompt Prompt to moderate
+ * @returns true if the prompt is safe, throws an error otherwise
+ */
+const moderateIncomingPrompt = async (prompt: string) => {
+	cli.print("[MODERATION] Checking user prompt...");
+	const moderationResponse = await openai.createModeration({
+		input: prompt
+	});
+
+	const moderationResponseData = moderationResponse.data;
+	const moderationResponseCategories = moderationResponseData.results[0].categories;
+	const blackListedCategories = config.promptModerationBacklistedCategories;
+
+	cli.print(`[MODERATION] OpenAI Moderation response: ${JSON.stringify(moderationResponseData)}`);
+
+	// Check if any of the backlisted categories are set to true
+	for (const category of blackListedCategories) {
+		if (moderationResponseCategories[category]) {
+			cli.print(`[MODERATION] Prompt was rejected by the moderation system. Category: ${category}`);
+			throw new Error(`Prompt was rejected by the moderation system. Reason: ${category}`);
+		}
+	}
+
+	cli.print("[MODERATION] Prompt was accepted by the moderation system.");
+
+	return true;
+};
+
+export { moderateIncomingPrompt };


### PR DESCRIPTION
Added an optional Moderation system using the [OpenAI Moderation API](https://beta.openai.com/docs/api-reference/moderations)

If the moderation module detects that a prompt violates OpenAI's Content Policy, it won't be sent into either ChatGPT or Dalle, instead, we will send the user an error message.