### PR TITLE
Configure model when prefix disabled

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -27,6 +27,9 @@ DALLE_PREFIX=!dalle
 RESET_PREFIX=!reset
 AI_CONFIG_PREFIX=!config
 
+# Whether or not to use ChatGPT When Prefixes are enabled but still prefix is empty
+NOPREFIX_IS_GPT=false
+
 # Prompt Moderation
 # If enabled, the bot will check any prompts submitted by users with the OpenAI Moderation API
 # If the prompt is classified as any of the categories in the blacklisted categories, the prompt will be rejected

--- a/docs/pages/configure-prefix.md
+++ b/docs/pages/configure-prefix.md
@@ -15,3 +15,4 @@ GPT_PREFIX=!gpt
 DALLE_PREFIX=!dalle
 AI_CONFIG_PREFIX=!config
 ```
+You can set `NOPREFIX_IS_GPT` to `true` to enable handing the message via GPT if user gives no prefix.  

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,7 @@ interface IConfig {
 	dallePrefix: string;
 	resetPrefix: string;
 	aiConfigPrefix: string;
+	noPrefixIsGpt: boolean;
 
 	// Prompt Moderation
 	promptModerationEnabled: boolean;
@@ -55,6 +56,7 @@ const config: IConfig = {
 	// Prefix
 	prefixEnabled: getEnvBooleanWithDefault("PREFIX_ENABLED", true), // Default: true
 	prefixSkippedForMe: getEnvBooleanWithDefault("PREFIX_SKIPPED_FOR_ME", true), // Default: true
+	noPrefixIsGpt: getEnvBooleanWithDefault("PREFIX_ENABLED", false), // Default: true
 	gptPrefix: process.env.GPT_PREFIX || "!gpt", // Default: !gpt
 	dallePrefix: process.env.DALLE_PREFIX || "!dalle", // Default: !dalle
 	resetPrefix: process.env.RESET_PREFIX || "!reset", // Default: !reset

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,7 +56,7 @@ const config: IConfig = {
 	// Prefix
 	prefixEnabled: getEnvBooleanWithDefault("PREFIX_ENABLED", true), // Default: true
 	prefixSkippedForMe: getEnvBooleanWithDefault("PREFIX_SKIPPED_FOR_ME", true), // Default: true
-	noPrefixIsGpt: getEnvBooleanWithDefault("PREFIX_ENABLED", false), // Default: true
+	noPrefixIsGpt: getEnvBooleanWithDefault("NOPREFIX_IS_GPT", false), // Default: true
 	gptPrefix: process.env.GPT_PREFIX || "!gpt", // Default: !gpt
 	dallePrefix: process.env.DALLE_PREFIX || "!dalle", // Default: !dalle
 	resetPrefix: process.env.RESET_PREFIX || "!reset", // Default: !reset

--- a/src/handlers/message.ts
+++ b/src/handlers/message.ts
@@ -118,8 +118,14 @@ async function handleIncomingMessage(message: Message) {
 		return;
 	}
 
-	// GPT (only <prompt>)
+	// DALLE (!dalle <prompt>)
+	if (startsWithIgnoreCase(messageString, config.dallePrefix)) {
+		const prompt = messageString.substring(config.dallePrefix.length + 1);
+		await handleMessageDALLE(message, prompt);
+		return;
+	}
 
+	// GPT (only <prompt>)
 	const selfNotedMessage = message.fromMe && message.hasQuotedMsg === false && message.from === message.to;
 
 	// GPT (!gpt <prompt>)
@@ -129,10 +135,9 @@ async function handleIncomingMessage(message: Message) {
 		return;
 	}
 
-	// DALLE (!dalle <prompt>)
-	if (startsWithIgnoreCase(messageString, config.dallePrefix)) {
-		const prompt = messageString.substring(config.dallePrefix.length + 1);
-		await handleMessageDALLE(message, prompt);
+	// If None of the prompts is given but noPrefixIsGpt is set , then fall back to GPT
+	if ( config.prefixEnabled && config.noPrefixIsGpt ) {
+		await handleMessageGPT(message, messageString);
 		return;
 	}
 


### PR DESCRIPTION
With this, I wish to suggest that let's add an option NOPREFIX_IS_GPT. Which means if we have prefixes enabled, a message without a prefix can be treated as a message to GPT. This way I can provide a default natural GPT chat to my consumers and they only pass a prefix when they want to use DallE. 
I ran the app for a couple of days and my friends are having a lot of fun. But a lot of times they just send the message and suddenly it strikes they forgot to add !gpt. 