### PR TITLE
Update whatsapp-web to v1.19.5 to fix dalle command and voice command

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"openai": "^3.1.0",
 		"picocolors": "^1.0.0",
 		"qrcode-terminal": "^0.12.0",
-		"whatsapp-web.js": "^1.19.4",
+		"whatsapp-web.js": "^1.19.5",
 		"aws-sdk": "^2.1332.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Fix for broken dalle command which was fixed by updated whatsapp-web to v1.19.5:
`Fix for error when send files: Error: Evaluation failed: TypeError: window.Store.MediaPrep.prepRawMedia is not a function`