### PR TITLE
fix: github action failed due to invalid package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"openai": "^3.1.0",
 				"picocolors": "^1.0.0",
 				"qrcode-terminal": "^0.12.0",
-				"whatsapp-web.js": "^1.19.4"
+				"whatsapp-web.js": "^1.19.5"
 			},
 			"devDependencies": {
 				"@types/fluent-ffmpeg": "^2.1.21",
@@ -1629,9 +1629,9 @@
 			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
 		},
 		"node_modules/whatsapp-web.js": {
-			"version": "1.19.4",
-			"resolved": "https://registry.npmjs.org/whatsapp-web.js/-/whatsapp-web.js-1.19.4.tgz",
-			"integrity": "sha512-qwfdauW3rKsI2gzRexFU5y+SumXjuZTidyZXFIXaWfPzMe4ejxAkVoj/u27wyNZDqK3Z8tI/Ac3ZJFG60VgA6w==",
+			"version": "1.19.5",
+			"resolved": "https://registry.npmjs.org/whatsapp-web.js/-/whatsapp-web.js-1.19.5.tgz",
+			"integrity": "sha512-tavnhcQEbmlTzzLDVqqxIjWllsOwM0/5hhASame3bKEUT7Wk+q0z8g3cYMk43Eqdip1bK1rqUvwzzD3lDNfwCA==",
 			"dependencies": {
 				"@pedroslopez/moduleraid": "^5.0.2",
 				"fluent-ffmpeg": "^2.1.2",


### PR DESCRIPTION
one of GitHub's actions failed with the command "npm ci" because the package.json and package-lock.json are not synced.