### PR TITLE
OpenAI Token Pool

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -8,6 +8,10 @@
 # Get your key here: https://platform.openai.com/account/api-keys
 OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
+# In case you run into ratelimit on a single organization token, you might setting up multiple API keys here
+# Example:
+# OPENAI_API_KEYS=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
 # GPT Model (default: gpt-3.5-turbo)
 OPENAI_GPT_MODEL=
 

--- a/docs/pages/gpt.md
+++ b/docs/pages/gpt.md
@@ -1,6 +1,7 @@
 # GPT
 
 ## Model
+
 You can specify the model which should be used with the `OPENAI_MODEL` environment variabl
 
 ```bash

--- a/docs/pages/gpt.md
+++ b/docs/pages/gpt.md
@@ -60,3 +60,9 @@ PROMPT_MODERATION_BLACKLISTED_CATEGORIES = ["hate","hate/threatening","self-harm
 You can see all available categories [here](https://beta.openai.com/docs/api-reference/moderations).
 
 Please, keep in mind that disabling the prompt moderation or modifying the blacklisted categories, will not disable the moderation of the GPT API. Because OpenAI uses their own moderation, which is not configurable.
+
+## Rate Limit
+
+https://platform.openai.com/docs/guides/rate-limits
+
+If you are with heavy usage, you might run into the rate limit of Open API. Since the rate limit is on organization level, you could create another account and get a new API key separately. And then setting the keys into environment variables `OPENAI_API_KEYS`. API keys will be used in a random basis.

--- a/docs/pages/usage.md
+++ b/docs/pages/usage.md
@@ -22,7 +22,9 @@ To modify the bot's configuration, you can use the `!config` command. Run `!conf
 Available commands:
 	!config dalle size <value> - Set dalle size to <value>
 	!config chat id - Get the ID of the chat
+	!config general settings - Get current settings
 	!config general whitelist <value> - Set whitelisted phone numbers
+	!config gpt apiKey <value> - Set token pool, support multiple tokens with comma-separated
 	!config gpt maxModelTokens <value> - Set max model tokens value
 	!config transcription enabled <value> - Toggle if transcription is enabled
 	!config transcription mode <value> - Set transcription mode
@@ -30,6 +32,7 @@ Available commands:
 
 Available values:
 	dalle size: 256x256, 512x512, 1024x1024
+	gpt apiKey: sk-xxxx,sk-xxxx
 	gpt maxModelTokens: integer
 	transcription enabled: true, false
 	transcription mode: local, speech-api, whisper-api, openai

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"openai": "^3.1.0",
 		"picocolors": "^1.0.0",
 		"qrcode-terminal": "^0.12.0",
-		"whatsapp-web.js": "^1.19.4",
+		"whatsapp-web.js": "^1.19.5",
 		"aws-sdk": "^2.1332.0"
 	},
 	"devDependencies": {

--- a/src/commands/general.ts
+++ b/src/commands/general.ts
@@ -27,7 +27,7 @@ const settings: ICommandDefinition = {
 		for (let module in aiConfig.commandsMap) {
 			for (let command in aiConfig.commandsMap[module]) {
 				if (aiConfig.commandsMap[module][command].data === undefined) {
-					continue
+					continue;
 				}
 				let val;
 				if (typeof aiConfig.commandsMap[module][command].data === "function") {

--- a/src/commands/general.ts
+++ b/src/commands/general.ts
@@ -1,13 +1,67 @@
 import { ICommandModule, ICommandDefinition, ICommandsMap } from "../types/commands";
 import { Message } from "whatsapp-web.js";
 import { config } from "../config";
+import { aiConfigTarget, aiConfigTypes, aiConfigValues, IAiConfig } from "../types/ai-config";
+import { aiConfig, getConfig } from "../handlers/ai-config";
 
 export const GeneralModule: ICommandModule = {
 	key: "general",
 	register: (): ICommandsMap => {
 		return {
+			settings,
 			whitelist
 		};
+	}
+};
+
+const settings: ICommandDefinition = {
+	help: "- Get current settings",
+	execute: function (message: Message) {
+		const selfNotedMessage = message.fromMe && message.hasQuotedMsg === false && message.from === message.to;
+		if (!selfNotedMessage) {
+			// Only allow printing out the settings on self-noted for security reasons
+			return;
+		}
+
+		let response = "Runtime settings:";
+		for (let module in aiConfig.commandsMap) {
+			for (let command in aiConfig.commandsMap[module]) {
+				if (aiConfig.commandsMap[module][command].data === undefined) {
+					continue
+				}
+				let val;
+				if (typeof aiConfig.commandsMap[module][command].data === "function") {
+					val = aiConfig.commandsMap[module][command].data();
+				} else {
+					val = aiConfig.commandsMap[module][command].data;
+				}
+				response += `\n${module} ${command}: ${val}`;
+			}
+		}
+
+		response += `\n\nStatic settings:`;
+
+		for (let target in aiConfigTarget) {
+			for (let type in aiConfigTypes[target]) {
+				response += `\n${target} ${type}: ${aiConfig[target][type]}`;
+			}
+		}
+
+		// Whitelisted fields from config
+		[
+			"openAIModel",
+			"prePrompt",
+			"gptPrefix",
+			"dallePrefix",
+			"resetPrefix",
+			"groupchatsEnabled",
+			"promptModerationEnabled",
+			"promptModerationBlacklistedCategories",
+			"ttsMode"
+		].forEach((field) => {
+			response += `\n${field}: ${config[field]}`;
+		});
+		message.reply(response);
 	}
 };
 

--- a/src/commands/gpt.ts
+++ b/src/commands/gpt.ts
@@ -1,15 +1,34 @@
 import { ICommandModule, ICommandDefinition, ICommandsMap } from "../types/commands";
 import { Message } from "whatsapp-web.js";
 import { config } from "../config";
+import { initOpenAI } from "../providers/openai";
 
 export const GptModule: ICommandModule = {
 	key: "gpt",
 	register: (): ICommandsMap => {
 		return {
+			apiKey,
 			maxModelTokens
 		};
 	}
 };
+
+const apiKey: ICommandDefinition = {
+	help: "<value> - Set token pool, support multiple tokens with comma-separated",
+	hint: "sk-xxxx,sk-xxxx",
+	data: () => {
+		// Randomly pick an API key
+		return config.openAIAPIKeys[Math.floor(Math.random() * config.openAIAPIKeys.length)];
+	},
+	execute: function (message: Message, valueStr?: string) {
+		if (!valueStr) {
+			message.reply(`Invalid value, please give a comma-separated string of OpenAI api keys.`);
+			return;
+		}
+		config.openAIAPIKeys = valueStr.split(",") as string[];
+		message.reply(`Updated API keys, total keys: ${config.openAIAPIKeys.length}`);
+	}
+}
 
 const maxModelTokens: ICommandDefinition = {
 	help: "<value> - Set max model tokens value",
@@ -22,6 +41,7 @@ const maxModelTokens: ICommandDefinition = {
 			return;
 		}
 		this.data = value;
-		message.reply(`Updated whitelist phone numbers to ${this.data}`);
+		initOpenAI();
+		message.reply(`Updated max model tokens to ${this.data}`);
 	}
 };

--- a/src/commands/gpt.ts
+++ b/src/commands/gpt.ts
@@ -28,7 +28,7 @@ const apiKey: ICommandDefinition = {
 		config.openAIAPIKeys = valueStr.split(",") as string[];
 		message.reply(`Updated API keys, total keys: ${config.openAIAPIKeys.length}`);
 	}
-}
+};
 
 const maxModelTokens: ICommandDefinition = {
 	help: "<value> - Set max model tokens value",

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,11 +14,10 @@ interface IConfig {
 	whitelistedPhoneNumbers: string[];
 
 	// OpenAI
-	openAIAPIKey: string;
 	openAIModel: string;
+	openAIAPIKeys: string[];
 	maxModelTokens: number;
 	prePrompt: string | undefined;
-	chatgptModel: string;
 
 	// Prefix
 	prefixEnabled: boolean;
@@ -58,11 +57,10 @@ interface IConfig {
 export const config: IConfig = {
 	whitelistedPhoneNumbers: process.env.WHITELISTED_PHONE_NUMBERS?.split(",") || [],
 
-	openAIAPIKey: process.env.OPENAI_API_KEY || "", // Default: ""
+	openAIAPIKeys: (process.env.OPENAI_API_KEYS || process.env.OPENAI_API_KEY || "").split(",").filter((key) => !!key), // Default: []
 	openAIModel: process.env.OPENAI_GPT_MODEL || "gpt-3.5-turbo", // Default: gpt-3.5-turbo
 	maxModelTokens: getEnvMaxModelTokens(), // Default: 4096
 	prePrompt: process.env.PRE_PROMPT, // Default: undefined
-	chatgptModel: process.env.CHATGPT_MODEL || "gpt-3.5-turbo", // Default: "gpt-3.5-turbo"
 
 	// Prefix
 	prefixEnabled: getEnvBooleanWithDefault("PREFIX_ENABLED", true), // Default: true

--- a/src/handlers/ai-config.ts
+++ b/src/handlers/ai-config.ts
@@ -10,17 +10,15 @@ import { TTSModule } from "../commands/tts";
 
 import config from "../config";
 
-let aiConfig: IAiConfig;
+let aiConfig: IAiConfig = {
+	dalle: {
+		size: dalleImageSize["512x512"]
+	},
+	// chatgpt: {}
+	commandsMap: {}
+};
 
 const initAiConfig = () => {
-	aiConfig = {
-		dalle: {
-			size: dalleImageSize["512x512"]
-		},
-		// chatgpt: {}
-		commandsMap: {}
-	};
-
 	// Register commands
 	[ChatModule, GeneralModule, GptModule, TranscriptionModule, TTSModule].forEach((module) => {
 		aiConfig.commandsMap[module.key] = module.register();
@@ -91,12 +89,12 @@ const handleMessageAIConfig = async (message: Message, prompt: any) => {
 			return;
 		}
 
-		if (aiConfig.commandsMap[target]) {
+		if (target && type && aiConfig.commandsMap[target] && aiConfig.commandsMap[target][type]) {
 			aiConfig.commandsMap[target][type].execute(message, value);
 			return;
 		}
 
-		if (!(type in aiConfigTypes[target])) {
+		if (typeof aiConfigTypes[target] !== "object" || !(type in aiConfigTypes[target])) {
 			message.reply("Invalid type, please use one of the following: " + Object.keys(aiConfigTypes[target]).join(", "));
 			return;
 		}
@@ -121,6 +119,9 @@ export function getCommand(module: string, command: string): ICommandDefinition 
 
 export function getConfig(target: string, type: string): any {
 	if (aiConfig.commandsMap[target] && aiConfig.commandsMap[target][type]) {
+		if (typeof aiConfig.commandsMap[target][type].data === "function") {
+			return aiConfig.commandsMap[target][type].data();
+		}
 		return aiConfig.commandsMap[target][type].data;
 	}
 	return aiConfig[target][type];

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { handleIncomingMessage } from "./handlers/message";
 
 // Config
 import { initAiConfig } from "./handlers/ai-config";
+import { initOpenAI } from "./providers/openai";
 
 // Ready timestamp of the bot
 let botReadyTimestamp: Date | null = null;
@@ -62,6 +63,7 @@ const start = async () => {
 		botReadyTimestamp = new Date();
 
 		initAiConfig();
+		initOpenAI();
 	});
 
 	// WhatsApp message

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -7,25 +7,30 @@ import ffmpeg from "fluent-ffmpeg";
 import { Configuration, OpenAIApi } from "openai";
 import { blobFromSync, File } from "fetch-blob/from.js";
 import config from "../config";
+import { getConfig } from "../handlers/ai-config";
 
-let options = {
-	temperature: 0.7, // OpenAI parameter
-	max_tokens: config.maxModelTokens, // OpenAI parameter [Max response size by tokens]
-	top_p: 0.9, // OpenAI parameter
-	frequency_penalty: 0, // OpenAI parameter
-	presence_penalty: 0, // OpenAI parameter
-	// instructions: ``,
-	model: config.openAIModel // OpenAI model
-};
-
-export const chatgpt = new ChatGPT(config.openAIAPIKey, options); // Note: options is optional
+export let chatgpt:ChatGPT
 
 // OpenAI Client (DALL-E)
-export const openai = new OpenAIApi(
-	new Configuration({
-		apiKey: config.openAIAPIKey
-	})
-);
+export let openai:OpenAIApi
+
+export function initOpenAI() {
+	chatgpt = new ChatGPT(getConfig("gpt", "apiKey"), {
+		temperature: 0.7, // OpenAI parameter
+		max_tokens: getConfig("gpt", "maxModelTokens"), // OpenAI parameter [Max response size by tokens]
+		top_p: 0.9, // OpenAI parameter
+		frequency_penalty: 0, // OpenAI parameter
+		presence_penalty: 0, // OpenAI parameter
+		// instructions: ``,
+		model: config.openAIModel // OpenAI model
+	});
+
+	openai = new OpenAIApi(
+		new Configuration({
+			apiKey: getConfig("gpt", "apiKey")
+		})
+	);
+}
 
 export async function transcribeOpenAI(audioBuffer: Buffer): Promise<{ text: string; language: string }> {
 	const url = config.openAIServerUrl;
@@ -56,7 +61,7 @@ export async function transcribeOpenAI(audioBuffer: Buffer): Promise<{ text: str
 	}
 
 	const headers = new Headers();
-	headers.append("Authorization", `Bearer ${config.openAIAPIKey}`);
+	headers.append("Authorization", `Bearer ${getConfig("gpt", "apiKey")}`);
 
 	// Request options
 	const options = {

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -9,10 +9,10 @@ import { blobFromSync, File } from "fetch-blob/from.js";
 import config from "../config";
 import { getConfig } from "../handlers/ai-config";
 
-export let chatgpt:ChatGPT
+export let chatgpt: ChatGPT;
 
 // OpenAI Client (DALL-E)
-export let openai:OpenAIApi
+export let openai: OpenAIApi;
 
 export function initOpenAI() {
 	chatgpt = new ChatGPT(getConfig("gpt", "apiKey"), {


### PR DESCRIPTION
For some intensive use cases, you might being ratelimited by OpenAI. This PR allows user to setup multiple API keys such that you might add in more keys from different organization. Also new commands to show current setting values and set openai api keys, see help for detail.

```
Available commands:
	!config dalle size <value> - Set dalle size to <value>
	!config chat id - Get the ID of the chat
	!config general settings - Get current settings     <----------- NEW
	!config general whitelist <value> - Set whitelisted phone numbers
	!config gpt apiKey <value> - Set token pool, support multiple tokens with comma-separated     <----------- NEW
	!config gpt maxModelTokens <value> - Set max model tokens value
	!config transcription enabled <value> - Toggle if transcription is enabled
	!config transcription mode <value> - Set transcription mode
	!config tts enabled <value> - Toggle if TTS is enabled

Available values:
	dalle size: 256x256, 512x512, 1024x1024
	gpt apiKey: sk-xxxx,sk-xxxx     <----------- NEW
	gpt maxModelTokens: integer
	transcription enabled: true, false
	transcription mode: local, speech-api, whisper-api, openai
	tts enabled: true, false
```

