### PR TITLE
Add stable diffusion

### DIFF
--- a/docs/pages/configure-prefix.md
+++ b/docs/pages/configure-prefix.md
@@ -2,9 +2,9 @@
 
 ## Disable prefix
 
-You can disable the `!gpt`/`!dalle`/`!config` prefix by setting `PREFIX_ENABLED` to `false` in the `.env` file.<br/>
+You can disable the `!gpt`/`!dalle`/`!sd`/`!config` prefix by setting `PREFIX_ENABLED` to `false` in the `.env` file.<br/>
 
-If you disable the prefix, the bot will not support DALL-E, and only GPT will be used.
+If you disable the prefix, the bot will not support DALL-E and Stable Diffusion, only GPT will be used.
 
 ## Set own prefixes
 
@@ -13,5 +13,6 @@ You can set your own prefixes for ChatGPT, DALL-E and configuration in the `.env
 ```
 GPT_PREFIX=!gpt
 DALLE_PREFIX=!dalle
+STABLE_DIFFUSION_PREFIX=!sd
 AI_CONFIG_PREFIX=!config
 ```

--- a/docs/pages/usage.md
+++ b/docs/pages/usage.md
@@ -37,6 +37,7 @@ Available commands:
 	!config transcription enabled <value> - Toggle if transcription is enabled
 	!config transcription mode <value> - Set transcription mode
 	!config tts enabled <value> - Toggle if TTS is enabled
+	!config sd setModel <value> - Set the model to be used of Stable Diffusion (with huggingface)
 
 Available values:
 	dalle size: 256x256, 512x512, 1024x1024
@@ -45,4 +46,5 @@ Available values:
 	transcription enabled: true, false
 	transcription mode: local, speech-api, whisper-api, openai
 	tts enabled: true, false
+	sd setModel: runwayml/stable-diffusion-v1-5
 ```

--- a/docs/pages/usage.md
+++ b/docs/pages/usage.md
@@ -1,6 +1,6 @@
 # Usage
 
-To use the bot, simply send a message with the `!gpt`/`!dalle`/`!config` command followed by your prompt. For example:
+To use the bot, simply send a message with the `!gpt`/`!dalle`/`!sd`/`!config` command followed by your prompt. For example:
 
 ### GPT
 
@@ -13,6 +13,14 @@ To use the bot, simply send a message with the `!gpt`/`!dalle`/`!config` command
 ```
 !dalle A frog with a red hat is walking on a bridge.
 ```
+
+### Stable Diffusion
+
+```
+!sd A frog with a red hat is walking on a bridge.
+```
+
+It is using huggingface's stable diffusion model for image rendering, you might change the model with `!config sd setModel <model>` command.
 
 ### AI Config
 

--- a/src/commands/general.ts
+++ b/src/commands/general.ts
@@ -53,6 +53,7 @@ const settings: ICommandDefinition = {
 			"prePrompt",
 			"gptPrefix",
 			"dallePrefix",
+			"stableDiffusionPrefix",
 			"resetPrefix",
 			"groupchatsEnabled",
 			"promptModerationEnabled",

--- a/src/commands/stable-diffusion.ts
+++ b/src/commands/stable-diffusion.ts
@@ -1,0 +1,67 @@
+import { ICommandModule, ICommandDefinition, ICommandsMap } from "../types/commands";
+import { Message, MessageMedia } from "whatsapp-web.js";
+import * as cli from "../cli/ui";
+
+export const StableDiffusionModule: ICommandModule = {
+	key: "sd",
+	register: (): ICommandsMap => {
+		return {
+			setModel,
+			generate
+		};
+	}
+};
+
+let model = "runwayml/stable-diffusion-v1-5";
+
+const setModel: ICommandDefinition = {
+	help: "<value> - Set the model to be used",
+	hint: "runwayml/stable-diffusion-v1-5 from huggingface",
+	data: model,
+	execute: function (message: Message, valueStr?: string) {
+		if (!valueStr) {
+			message.reply(`Invalid value, please give a model name.`);
+			return;
+		}
+		this.data = valueStr;
+		model = valueStr;
+		message.reply(`Updated model to ${this.data}`);
+	}
+};
+
+const generate: ICommandDefinition = {
+	help: "<prompt> - Given the prompt, generate an image using Stable Diffusion (with huggingface)",
+	hint: 'A magical and adventurous story about "The Littlest Pudu."',
+	execute: async (message: Message, valueStr?: string) => {
+		try {
+			const start = Date.now();
+
+			cli.print(`[Stable Diffusion] Received prompt from ${message.from}: ${valueStr}`);
+
+			const url = `https://api-inference.huggingface.co/models/${model}`;
+			const options = {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${process.env.HUGGINGFACE_API_TOKEN}`
+				},
+				body: JSON.stringify({
+					inputs: valueStr
+				})
+			};
+			const response = await fetch(url, options);
+			const end = Date.now() - start;
+			const imageBlob = await response.blob();
+			const contentType = response.headers.get("Content-Type") || "image/jpeg";
+			const buffer = Buffer.from(await imageBlob.arrayBuffer());
+			const image = new MessageMedia(contentType, buffer.toString("base64"));
+
+			cli.print(`[Stable Diffusion] Answer to ${message.from} | Huggingface request took ${end}ms`);
+
+			message.reply(image);
+		} catch (error: any) {
+			console.error("An error occurred", error);
+			message.reply("An error occurred, please contact the administrator. (" + error.message + ")");
+		}
+	}
+};

--- a/src/commands/stable-diffusion.ts
+++ b/src/commands/stable-diffusion.ts
@@ -15,8 +15,8 @@ export const StableDiffusionModule: ICommandModule = {
 let model = "runwayml/stable-diffusion-v1-5";
 
 const setModel: ICommandDefinition = {
-	help: "<value> - Set the model to be used",
-	hint: "runwayml/stable-diffusion-v1-5 from huggingface",
+	help: "<value> - Set the model to be used of Stable Diffusion (with huggingface)",
+	hint: "runwayml/stable-diffusion-v1-5",
 	data: model,
 	execute: function (message: Message, valueStr?: string) {
 		if (!valueStr) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,10 +24,10 @@ interface IConfig {
 	prefixSkippedForMe: boolean;
 	gptPrefix: string;
 	dallePrefix: string;
+	stableDiffusionPrefix: string;
 	langChainPrefix: string;
 	resetPrefix: string;
 	aiConfigPrefix: string;
-	stableDiffusionPrefix: string;
 
 	// Groupchats
 	groupchatsEnabled: boolean;
@@ -69,10 +69,10 @@ export const config: IConfig = {
 	prefixSkippedForMe: getEnvBooleanWithDefault("PREFIX_SKIPPED_FOR_ME", true), // Default: true
 	gptPrefix: process.env.GPT_PREFIX || "!gpt", // Default: !gpt
 	dallePrefix: process.env.DALLE_PREFIX || "!dalle", // Default: !dalle
+	stableDiffusionPrefix: process.env.STABLE_DIFFUSION_PREFIX || "!sd", // Default: !sd
 	resetPrefix: process.env.RESET_PREFIX || "!reset", // Default: !reset
 	aiConfigPrefix: process.env.AI_CONFIG_PREFIX || "!config", // Default: !config
 	langChainPrefix: process.env.LANGCHAIN_PREFIX || "!lang", // Default: !lang
-	stableDiffusionPrefix: process.env.STABLE_DIFFUSION_PREFIX || "!sd", // Default: !sd
 
 	// Groupchats
 	groupchatsEnabled: getEnvBooleanWithDefault("GROUPCHATS_ENABLED", false), // Default: false

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,7 @@ interface IConfig {
 	langChainPrefix: string;
 	resetPrefix: string;
 	aiConfigPrefix: string;
+	stableDiffusionPrefix: string;
 
 	// Groupchats
 	groupchatsEnabled: boolean;
@@ -71,6 +72,7 @@ export const config: IConfig = {
 	resetPrefix: process.env.RESET_PREFIX || "!reset", // Default: !reset
 	aiConfigPrefix: process.env.AI_CONFIG_PREFIX || "!config", // Default: !config
 	langChainPrefix: process.env.LANGCHAIN_PREFIX || "!lang", // Default: !lang
+	stableDiffusionPrefix: process.env.STABLE_DIFFUSION_PREFIX || "!sd", // Default: !sd
 
 	// Groupchats
 	groupchatsEnabled: getEnvBooleanWithDefault("GROUPCHATS_ENABLED", false), // Default: false

--- a/src/handlers/ai-config.ts
+++ b/src/handlers/ai-config.ts
@@ -7,6 +7,7 @@ import { ICommandDefinition } from "../types/commands";
 import { GptModule } from "../commands/gpt";
 import { TranscriptionModule } from "../commands/transcription";
 import { TTSModule } from "../commands/tts";
+import { StableDiffusionModule } from "../commands/stable-diffusion";
 
 import config from "../config";
 
@@ -20,7 +21,7 @@ let aiConfig: IAiConfig = {
 
 const initAiConfig = () => {
 	// Register commands
-	[ChatModule, GeneralModule, GptModule, TranscriptionModule, TTSModule].forEach((module) => {
+	[ChatModule, GeneralModule, GptModule, TranscriptionModule, TTSModule, StableDiffusionModule].forEach((module) => {
 		aiConfig.commandsMap[module.key] = module.register();
 	});
 	console.log("[AI-Config] Initialized AI config");
@@ -82,7 +83,7 @@ const handleMessageAIConfig = async (message: Message, prompt: any) => {
 
 		const target: string = args[0];
 		const type: string = args[1];
-		const value: string | undefined = args.length == 3 ? args[2] : undefined;
+		let value: string | undefined = args.length >= 3 ? args.slice(2).join(" ") : undefined;
 
 		if (!(target in aiConfigTarget) && !(target in aiConfig.commandsMap)) {
 			message.reply("Invalid target, please use one of the following: " + Object.keys(aiConfigTarget).join(", "));
@@ -129,6 +130,14 @@ export function getConfig(target: string, type: string): any {
 		return aiConfig.commandsMap[target][type].data;
 	}
 	return aiConfig[target][type];
+}
+
+export function executeCommand(target: string, type: string, message: Message, value: string | undefined) {
+	if (aiConfig.commandsMap[target] && aiConfig.commandsMap[target][type]) {
+		if (typeof aiConfig.commandsMap[target][type].execute === "function") {
+			return aiConfig.commandsMap[target][type].execute(message, value);
+		}
+	}
 }
 
 export { aiConfig, handleMessageAIConfig, initAiConfig };

--- a/src/handlers/ai-config.ts
+++ b/src/handlers/ai-config.ts
@@ -83,7 +83,7 @@ const handleMessageAIConfig = async (message: Message, prompt: any) => {
 
 		const target: string = args[0];
 		const type: string = args[1];
-		let value: string | undefined = args.length >= 3 ? args.slice(2).join(" ") : undefined;
+		const value: string | undefined = args.length >= 3 ? args.slice(2).join(" ") : undefined;
 
 		if (!(target in aiConfigTarget) && !(target in aiConfig.commandsMap)) {
 			message.reply("Invalid target, please use one of the following: " + Object.keys(aiConfigTarget).join(", "));
@@ -132,7 +132,7 @@ export function getConfig(target: string, type: string): any {
 	return aiConfig[target][type];
 }
 
-export function executeCommand(target: string, type: string, message: Message, value: string | undefined) {
+export function executeCommand(target: string, type: string, message: Message, value?: string | undefined) {
 	if (aiConfig.commandsMap[target] && aiConfig.commandsMap[target][type]) {
 		if (typeof aiConfig.commandsMap[target][type].execute === "function") {
 			return aiConfig.commandsMap[target][type].execute(message, value);

--- a/src/handlers/message.ts
+++ b/src/handlers/message.ts
@@ -10,7 +10,7 @@ import * as cli from "../cli/ui";
 // ChatGPT & DALLE
 import { handleMessageGPT, handleDeleteConversation } from "../handlers/gpt";
 import { handleMessageDALLE } from "../handlers/dalle";
-import { handleMessageAIConfig, getConfig } from "../handlers/ai-config";
+import { handleMessageAIConfig, getConfig, executeCommand } from "../handlers/ai-config";
 import { handleMessageLangChain } from "../handlers/langchain";
 
 // Speech API & Whisper
@@ -150,6 +150,13 @@ async function handleIncomingMessage(message: Message) {
 	if (startsWithIgnoreCase(messageString, config.dallePrefix)) {
 		const prompt = messageString.substring(config.dallePrefix.length + 1);
 		await handleMessageDALLE(message, prompt);
+		return;
+	}
+
+	// Stable Diffusion (!sd <prompt>)
+	if (startsWithIgnoreCase(messageString, config.stableDiffusionPrefix)) {
+		const prompt = messageString.substring(config.stableDiffusionPrefix.length + 1);
+		await executeCommand("sd", "generate", message, prompt);
 		return;
 	}
 


### PR DESCRIPTION
This PR adds a command to use Stable Diffusion (huggingface) to generate image by using `!sd`

Example:

```
!sd A frog with a red hat is walking on a bridge.
```

<img width="398" alt="Screenshot 2023-04-26 at 2 19 42 PM" src="https://user-images.githubusercontent.com/4179665/234489191-ec417a4d-4304-45a2-ac8c-5b2dbc4a1881.png">

By default this command is using `runwayml/stable-diffusion-v1-5` ([Link](https://huggingface.co/runwayml/stable-diffusion-v1-5)), you can change it with command like:

```
!config sd setModel stabilityai/stable-diffusion-2-1
```