### PR TITLE
fixes data.id.id.length by Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"openai": "^3.1.0",
 		"picocolors": "^1.0.0",
 		"qrcode-terminal": "^0.12.0",
-		"whatsapp-web.js": "^1.19.5",
+		"whatsapp-web.js": "^^1.20.0",
 		"aws-sdk": "^2.1332.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
this.deviceType = data.id.id.length > 21 ? 'android' : data.id.id.substring(0, 2) == '3A' ? 'ios' : 'web'; ^
TypeError: data.id.id.substring is not a function
at Message._patch (/app/node_modules/whatsapp-web.js/src/structures/Message.js:91:75) at new Message (/app/node_modules/whatsapp-web.js/src/structures/Message.js:18:24) at Client.sendMessage (/app/node_modules/whatsapp-web.js/src/Client.js:699:16) at processTicksAndRejections (node:internal/process/task_queues:95:5)