### PR TITLE
Update .env-example

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -7,6 +7,8 @@
 
 # Get your key here: https://platform.openai.com/account/api-keys
 OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# HuggingFace API Token https://huggingface.co/settings/tokens
 HUGGINGFACE_API_TOKEN=hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # In case you run into ratelimit on a single organization token, you might setting up multiple API keys here
@@ -97,6 +99,3 @@ AWS_POLLY_VOICE_ENGINE=standard
 
 # LangChain Tool Config https://js.langchain.com/docs/modules/agents/tools/
 SERPAPI_API_KEY=xxxxxxxxx
-
-# HuggingFace API Token https://huggingface.co/settings/tokens
-HUGGINGFACE_API_TOKEN=hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx


### PR DESCRIPTION
There were two places where HUGGINGFACE_API_TOKEN was defined. The latter overrode the former. So when setting the token only at the top of the file a user would get access denied errors due to invalid token being actually taken from the end of the file.