### PR TITLE
added functionality to always reset the context

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -37,6 +37,9 @@ DALLE_PREFIX=!dalle
 RESET_PREFIX=!reset
 AI_CONFIG_PREFIX=!config
 
+# Wether or not to always reset the previous context
+ALWAYS_RESET=true
+
 # Whether or not to allow the bot interacting on groupchats
 GROUPCHATS_ENABLED=false
 

--- a/src/commands/general.ts
+++ b/src/commands/general.ts
@@ -55,6 +55,7 @@ const settings: ICommandDefinition = {
 			"dallePrefix",
 			"stableDiffusionPrefix",
 			"resetPrefix",
+      "alwaysResetEnabled",
 			"groupchatsEnabled",
 			"promptModerationEnabled",
 			"promptModerationBlacklistedCategories",

--- a/src/commands/general.ts
+++ b/src/commands/general.ts
@@ -55,7 +55,7 @@ const settings: ICommandDefinition = {
 			"dallePrefix",
 			"stableDiffusionPrefix",
 			"resetPrefix",
-      "alwaysResetEnabled",
+          "alwaysResetEnabled",
 			"groupchatsEnabled",
 			"promptModerationEnabled",
 			"promptModerationBlacklistedCategories",

--- a/src/commands/general.ts
+++ b/src/commands/general.ts
@@ -55,7 +55,7 @@ const settings: ICommandDefinition = {
 			"dallePrefix",
 			"stableDiffusionPrefix",
 			"resetPrefix",
-          "alwaysResetEnabled",
+                        "alwaysResetEnabled",
 			"groupchatsEnabled",
 			"promptModerationEnabled",
 			"promptModerationBlacklistedCategories",

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,10 @@ interface IConfig {
 	resetPrefix: string;
 	aiConfigPrefix: string;
 
+  // Always reset context enabled
+  alwaysResetEnabled: boolean;
+
+
 	// Groupchats
 	groupchatsEnabled: boolean;
 
@@ -74,6 +78,9 @@ export const config: IConfig = {
 	resetPrefix: process.env.RESET_PREFIX || "!reset", // Default: !reset
 	aiConfigPrefix: process.env.AI_CONFIG_PREFIX || "!config", // Default: !config
 	langChainPrefix: process.env.LANGCHAIN_PREFIX || "!lang", // Default: !lang
+
+  // Always reset context
+  alwaysResetEnabled: getEnvBooleanWithDefault("ALWAYS_RESET", false),  // Default: false
 
 	// Groupchats
 	groupchatsEnabled: getEnvBooleanWithDefault("GROUPCHATS_ENABLED", false), // Default: false

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,8 +29,8 @@ interface IConfig {
 	resetPrefix: string;
 	aiConfigPrefix: string;
 
-      // Always reset context enabled
-      alwaysResetEnabled: boolean;
+        // Always reset context enabled
+        alwaysResetEnabled: boolean;
 
 	// Groupchats
 	groupchatsEnabled: boolean;
@@ -78,8 +78,8 @@ export const config: IConfig = {
 	aiConfigPrefix: process.env.AI_CONFIG_PREFIX || "!config", // Default: !config
 	langChainPrefix: process.env.LANGCHAIN_PREFIX || "!lang", // Default: !lang
 
-      // Always reset context
-      alwaysResetEnabled: getEnvBooleanWithDefault("ALWAYS_RESET", false),  // Default: false
+        // Always reset context
+        alwaysResetEnabled: getEnvBooleanWithDefault("ALWAYS_RESET", false),  // Default: false
 
 	// Groupchats
 	groupchatsEnabled: getEnvBooleanWithDefault("GROUPCHATS_ENABLED", false), // Default: false

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,9 +29,8 @@ interface IConfig {
 	resetPrefix: string;
 	aiConfigPrefix: string;
 
-  // Always reset context enabled
-  alwaysResetEnabled: boolean;
-
+      // Always reset context enabled
+      alwaysResetEnabled: boolean;
 
 	// Groupchats
 	groupchatsEnabled: boolean;
@@ -79,8 +78,8 @@ export const config: IConfig = {
 	aiConfigPrefix: process.env.AI_CONFIG_PREFIX || "!config", // Default: !config
 	langChainPrefix: process.env.LANGCHAIN_PREFIX || "!lang", // Default: !lang
 
-  // Always reset context
-  alwaysResetEnabled: getEnvBooleanWithDefault("ALWAYS_RESET", false),  // Default: false
+      // Always reset context
+      alwaysResetEnabled: getEnvBooleanWithDefault("ALWAYS_RESET", false),  // Default: false
 
 	// Groupchats
 	groupchatsEnabled: getEnvBooleanWithDefault("GROUPCHATS_ENABLED", false), // Default: false

--- a/src/handlers/gpt.ts
+++ b/src/handlers/gpt.ts
@@ -84,12 +84,14 @@ const handleMessageGPT = async (message: Message, prompt: string) => {
 	}
 };
 
-const handleDeleteConversation = async (message: Message) => {
+const handleDeleteConversation = async (message: Message, sendReply: boolean) => {
 	// Delete conversation
 	delete conversations[message.from];
 
 	// Reply
-	message.reply("Conversation context was resetted!");
+  if (sendReply) {
+    message.reply("Conversation context was resetted!");
+  }
 };
 
 async function sendVoiceMessageReply(message: Message, gptTextResponse: string) {

--- a/src/handlers/gpt.ts
+++ b/src/handlers/gpt.ts
@@ -89,9 +89,9 @@ const handleDeleteConversation = async (message: Message, sendReply: boolean) =>
 	delete conversations[message.from];
 
 	// Reply
-      if (sendReply) {
-        message.reply("Conversation context was resetted!");
-      }
+        if (sendReply) {
+         	message.reply("Conversation context was resetted!");
+        }
 };
 
 async function sendVoiceMessageReply(message: Message, gptTextResponse: string) {

--- a/src/handlers/gpt.ts
+++ b/src/handlers/gpt.ts
@@ -89,9 +89,9 @@ const handleDeleteConversation = async (message: Message, sendReply: boolean) =>
 	delete conversations[message.from];
 
 	// Reply
-  if (sendReply) {
-    message.reply("Conversation context was resetted!");
-  }
+      if (sendReply) {
+        message.reply("Conversation context was resetted!");
+      }
 };
 
 async function sendVoiceMessageReply(message: Message, gptTextResponse: string) {

--- a/src/handlers/message.ts
+++ b/src/handlers/message.ts
@@ -135,9 +135,9 @@ async function handleIncomingMessage(message: Message) {
 
 	// GPT (!gpt <prompt>)
 	if (startsWithIgnoreCase(messageString, config.gptPrefix)) {
-        if (config.alwaysResetEnabled) {
-          await handleDeleteConversation(message, false);
-        }
+        	if (config.alwaysResetEnabled) {
+         		await handleDeleteConversation(message, false);
+        	}
 		const prompt = messageString.substring(config.gptPrefix.length + 1);
 		await handleMessageGPT(message, prompt);
 		return;

--- a/src/handlers/message.ts
+++ b/src/handlers/message.ts
@@ -122,7 +122,7 @@ async function handleIncomingMessage(message: Message) {
 
 	// Clear conversation context (!clear)
 	if (startsWithIgnoreCase(messageString, config.resetPrefix)) {
-		await handleDeleteConversation(message);
+		await handleDeleteConversation(message, true);
 		return;
 	}
 
@@ -135,6 +135,9 @@ async function handleIncomingMessage(message: Message) {
 
 	// GPT (!gpt <prompt>)
 	if (startsWithIgnoreCase(messageString, config.gptPrefix)) {
+    if (config.alwaysResetEnabled) {
+      await handleDeleteConversation(message, false);
+    }
 		const prompt = messageString.substring(config.gptPrefix.length + 1);
 		await handleMessageGPT(message, prompt);
 		return;

--- a/src/handlers/message.ts
+++ b/src/handlers/message.ts
@@ -135,9 +135,9 @@ async function handleIncomingMessage(message: Message) {
 
 	// GPT (!gpt <prompt>)
 	if (startsWithIgnoreCase(messageString, config.gptPrefix)) {
-    if (config.alwaysResetEnabled) {
-      await handleDeleteConversation(message, false);
-    }
+        if (config.alwaysResetEnabled) {
+          await handleDeleteConversation(message, false);
+        }
 		const prompt = messageString.substring(config.gptPrefix.length + 1);
 		await handleMessageGPT(message, prompt);
 		return;


### PR DESCRIPTION
I've noticed that, particularly in chat groups, the AI bot using the GPT-4-turbo model sometimes loses context and starts over from scratch. Consequently, I frequently had to use the `!reset` command, which became quite tedious. To address this, I made a new configuration that allows for the automatic reset of the bot's context with every message, making it more useful.