### PR TITLE
Update cosign installer to v3.5.0 and cosign-release to v2.2.4

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,9 +39,9 @@ jobs:
             # https://github.com/sigstore/cosign-installer
             - name: Install cosign
               if: github.event_name != 'pull_request'
-              uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
+              uses: sigstore/cosign-installer@v3.5.0
               with:
-                  cosign-release: "v1.13.1"
+                  cosign-release: "v2.2.4"
 
             # Workaround: https://github.com/docker/build-push-action/issues/461
             - name: Setup Docker buildx


### PR DESCRIPTION
Updated the cosign installer version to v3.5.0 and set the cosign-release to v2.2.4 in the workflow file for Docker actions.
This should fix the [pipeline issue](https://github.com/askrella/whatsapp-chatgpt/actions/runs/9695811699/job/26756374408) that currently exists 

![image](https://github.com/askrella/whatsapp-chatgpt/assets/11443716/5dbd27b4-79ee-4f2b-a787-04a806513c88)
